### PR TITLE
Fixed plugin replacement

### DIFF
--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -58,8 +58,9 @@ define ohmyzsh::plugins(
 
   file_line { "${name}-${plugins_real}-install":
     path    => "${home}/.zshrc",
-    line    => "plugins=(${plugins_real})",
-    match   => '^plugins=',
+    line    => "  ${plugins_real}",
+    after   => 'plugins=\(',
+    match   => '^  git',
     require => Ohmyzsh::Install[$name]
   }
 }

--- a/spec/defines/plugins_spec.rb
+++ b/spec/defines/plugins_spec.rb
@@ -44,7 +44,8 @@ describe 'ohmyzsh::plugins' do
           it do
             is_expected.to contain_file_line("#{user}-#{values[:expect][:plugins]}-install")
               .with_path("#{values[:expect][:home]}/.zshrc")
-              .with_line("plugins=(#{values[:expect][:plugins]})")
+              .with_line("  #{values[:expect][:plugins]}")
+              .with_after('plugins=\\(')
           end
         end
       end


### PR DESCRIPTION
Looks like the base .zshrc changed the plugin section.
The existing match and replace generated an error when logging in.
Basically
plugins=( git )
changed
to
plugins=(
  git
)

So changed the file_line resource to match the new expression