### PR TITLE
Fix plugin breaking change

### DIFF
--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -57,10 +57,19 @@ define ohmyzsh::plugins(
   $plugins_real = join($all_plugins, ' ')
 
   file_line { "${name}-${plugins_real}-install":
-    path    => "${home}/.zshrc",
-    line    => "  ${plugins_real}",
-    after   => 'plugins=\(',
-    match   => '^  git',
-    require => Ohmyzsh::Install[$name]
+    path               => "${home}/.zshrc",
+    line               => "  ${plugins_real}",
+    after              => '^\s*plugins=\([^\)]*$',
+    match              => '^\s*git',
+    append_on_no_match => false,
+    require            => Ohmyzsh::Install[$name]
+  }
+
+  file_line { "${name}-${plugins_real}-install-legacy":
+    path               => "${home}/.zshrc",
+    line               => "plugins=(${plugins_real})",
+    match              => '^\s*plugins=\(.*\)',
+    append_on_no_match => false,
+    require            => Ohmyzsh::Install[$name]
   }
 }

--- a/spec/defines/plugins_spec.rb
+++ b/spec/defines/plugins_spec.rb
@@ -45,7 +45,14 @@ describe 'ohmyzsh::plugins' do
             is_expected.to contain_file_line("#{user}-#{values[:expect][:plugins]}-install")
               .with_path("#{values[:expect][:home]}/.zshrc")
               .with_line("  #{values[:expect][:plugins]}")
-              .with_after('plugins=\\(')
+              .with_after('^\s*plugins=\([^\)]*$')
+          end
+
+          it do
+            is_expected.to contain_file_line("#{user}-#{values[:expect][:plugins]}-install-legacy")
+              .with_path("#{values[:expect][:home]}/.zshrc")
+              .with_line("plugins=(#{values[:expect][:plugins]})")
+              .with_match('^\s*plugins=\(.*\)')
           end
         end
       end


### PR DESCRIPTION
Prior to this PR, the file_line logic was changed to only allow for
the new plugin defaults, which was across multiple lines. Unfortunately,
this causes any existing .zshrc to insert the plugin list in the wrong
place. This commit allows for the replacement of both the single line
plugin list and the multiline plugin list.

#11 broke any existing `.zshrc` files that had a `plugins=()` on a single line by adding the following line in the middle of a comment due to the regex.

~~~
# Example format: plugins=(rails git textmate ruby lighthouse)
  git bundler osx rake rbenv ruby cp docker docker-compose gem pip python rsync screen tmux sudo vagrant pass dotenv
# Add wisely, as too many plugins slow down shell startup.
plugins=(git bundler osx rake rbenv ruby cp docker docker-compose gem pip python rsync screen tmux sudo vagrant pass dotenv)
~~~


This PR has two limitations to be aware of. 

1. As with #11, the new format is limited to plugins that begin with `git`.
2. It will not add a `plugins=` line if one does not already exist in the `.zshrc`.