### PR TITLE
Support for proper FreeBSD shell path

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,0 +1,1 @@
+ohmyzsh::zsh_shell_path: '/usr/local/bin/zsh'


### PR DESCRIPTION
Added FreeBSD.yaml to specify the path for `zsh` on FreeBSD