### PR TITLE
Bumping dependency version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 5.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-vcsrepo",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "rehan-wget",


### PR DESCRIPTION
Changed the requirements for `puppetlabs-stdlib` to be as high as anything in the  8.x series, and for `puppetlabs-vcsrepro` to be as high as anything in the 5.x series.