### PR TITLE
updating default oh-my-zsh repo source

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,4 @@
 ---
-ohmyzsh::source: 'https://github.com/robbyrussell/oh-my-zsh.git'
+ohmyzsh::source: 'https://github.com/ohmyzsh/ohmyzsh.git'
 ohmyzsh::home: '/home'
 ohmyzsh::zsh_shell_path: '/usr/bin/zsh'

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -3,15 +3,15 @@ require 'spec_helper'
 testcases = {
   'user1' => {
     params: {},
-    expect: { source: 'https://github.com/robbyrussell/oh-my-zsh.git', home: '/home/user1', sh: false, override_template: false },
+    expect: { source: 'https://github.com/ohmyzsh/ohmyzsh.git', home: '/home/user1', sh: false, override_template: false },
   },
   'user2' => {
     params: { set_sh: true, disable_auto_update: true, override_template: true },
-    expect: { source: 'https://github.com/robbyrussell/oh-my-zsh.git', home: '/home/user2', sh: true, disable_auto_update: true, override_template: true },
+    expect: { source: 'https://github.com/ohmyzsh/ohmyzsh.git', home: '/home/user2', sh: true, disable_auto_update: true, override_template: true },
   },
   'root' => {
     params: {},
-    expect: { source: 'https://github.com/robbyrussell/oh-my-zsh.git', home: '/root', sh: false, override_template: false },
+    expect: { source: 'https://github.com/ohmyzsh/ohmyzsh.git', home: '/root', sh: false, override_template: false },
   },
 }
 


### PR DESCRIPTION
closes #26 

this fixes "Error: Path /root/.oh-my-zsh exists and is not the desired repository." and similar errors due to repo URL path change of ohmyzsh

Update install_spec.rb

updating default oh-my-zsh repo source

this fixes "Error: Path /root/.oh-my-zsh exists and is not the desired repository." and similar errors due to repo URL path change of ohmyzsh

Update install_spec.rb