### PR TITLE
fix group name issue - recover FreeBSD support

### DIFF
--- a/manifests/fetch/theme.pp
+++ b/manifests/fetch/theme.pp
@@ -8,9 +8,14 @@ define ohmyzsh::fetch::theme (
   include ohmyzsh
 
   if $name == 'root' {
-    $home = '/root'
+    $home  = '/root'
+    $group = fact('os.family') ? {
+      /(Free|Open)BSD/ => 'wheel',
+      default          => 'root',
+    }
   } else {
-    $home = "${ohmyzsh::home}/${name}"
+    $home  = "${ohmyzsh::home}/${name}"
+    $group = $name
   }
 
   $themepath = "${home}/.oh-my-zsh/custom/themes"
@@ -36,7 +41,7 @@ define ohmyzsh::fetch::theme (
       ensure  => file,
       source  => $source,
       owner   => $name,
-      group   => $name,
+      group   => $group,
       mode    => '0644',
       require => File[$themepath],
     }
@@ -45,7 +50,7 @@ define ohmyzsh::fetch::theme (
       ensure  => file,
       content => $content,
       owner   => $name,
-      group   => $name,
+      group   => $group,
       mode    => '0644',
       require => File[$themepath],
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,9 +44,14 @@ define ohmyzsh::install (
   }
 
   if $name == 'root' {
-    $home = '/root'
+    $home  = '/root'
+    $group = fact('os.family') ? {
+      /(Free|Open)BSD/ => 'wheel',
+      default          => 'root',
+    }
   } else {
-    $home = "${ohmyzsh::home}/${name}"
+    $home  = "${ohmyzsh::home}/${name}"
+    $group = $name
   }
 
   vcsrepo { "${home}/.oh-my-zsh":
@@ -63,7 +68,7 @@ define ohmyzsh::install (
       ensure  => file,
       replace => 'no',
       owner   => $name,
-      group   => $name,
+      group   => $group,
       mode    => '0644',
       source  => "puppet:///modules/${module_name}/zshrc.zsh-template",
       require => Vcsrepo["${home}/.oh-my-zsh"],
@@ -107,7 +112,7 @@ define ohmyzsh::install (
     ensure  => directory,
     replace => 'no',
     owner   => $name,
-    group   => $name,
+    group   => $group,
     mode    => '0755',
     require => Vcsrepo["${home}/.oh-my-zsh"],
   }

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -35,9 +35,14 @@ define ohmyzsh::plugins(
   include ohmyzsh
 
   if $name == 'root' {
-    $home = '/root'
+    $home  = '/root'
+    $group = fact('os.family') ? {
+      /(Free|Open)BSD/ => 'wheel',
+      default          => 'root',
+    }
   } else {
-    $home = "${ohmyzsh::home}/${name}"
+    $home  = "${ohmyzsh::home}/${name}"
+    $group = $name
   }
 
   $custom_plugins_path = "${home}/.oh-my-zsh/custom/plugins"

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -19,16 +19,21 @@ define ohmyzsh::profile (
   include ohmyzsh
 
   if $name == 'root' {
-    $home = '/root'
+    $home  = '/root'
+    $group = fact('os.family') ? {
+      /(Free|Open)BSD/ => 'wheel',
+      default          => 'root',
+    }
   } else {
-    $home = "${ohmyzsh::home}/${name}"
+    $home  = "${ohmyzsh::home}/${name}"
+    $group = $name
   }
 
   $shell_resource_path = "${home}/.zshrc"
 
   file { "${home}/profile":
     ensure  => directory,
-    group   => $name,
+    group   => $group,
     owner   => $name,
     require => User[$name],
   }
@@ -47,7 +52,7 @@ define ohmyzsh::profile (
     file { "${home}/profile/${script_name}":
       ensure  => file,
       owner   => $name,
-      group   => $name,
+      group   => $group,
       mode    => '0744',
       source  => $script_path,
       require => File["${home}/profile"],

--- a/manifests/theme.pp
+++ b/manifests/theme.pp
@@ -28,9 +28,14 @@ define ohmyzsh::theme(
   include ohmyzsh
 
   if $name == 'root' {
-    $home = '/root'
+    $home  = '/root'
+    $group = fact('os.family') ? {
+      /(Free|Open)BSD/ => 'wheel',
+      default          => 'root',
+    }
   } else {
-    $home = "${ohmyzsh::home}/${name}"
+    $home  = "${ohmyzsh::home}/${name}"
+    $group = $name
   }
 
   file_line { "${name}-${theme}-install":

--- a/spec/defines/profile_spec.rb
+++ b/spec/defines/profile_spec.rb
@@ -25,7 +25,7 @@ describe 'ohmyzsh::profile' do
       testcases.each do |user, values|
         let(:pre_condition) do
           [
-            'user{"root": }',
+            'user {"root": }',
             'user {"user1": }',
             'user {"user2": }',
             'ohmyzsh::install {"root": set_sh => true, }',
@@ -39,9 +39,19 @@ describe 'ohmyzsh::profile' do
           let(:params) { values[:params] }
 
           it do
+            group = if user == 'root'
+                      case facts[:osfamily]
+                      when 'FreeBSD', 'OpenBSD'
+                        'wheel'
+                      else
+                        'root'
+                      end
+                    else
+                      user
+                    end
             is_expected.to contain_file("#{values[:expect][:home]}/profile")
               .with_ensure('directory')
-              .with_group(user)
+              .with_group(group)
               .with_owner(user)
           end
 


### PR DESCRIPTION
fix group name issue - recover FreeBSD support as we check the running OS as well as FreeBSD has not group named root, but wheel.