### PR TITLE
Add the ability to customize the clone for plugins

### DIFF
--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -25,9 +25,11 @@ define ohmyzsh::plugins(
   Array[String] $plugins        = ['git'],
   Hash[String,
     Struct[{
-        source => Enum[git],
-        url    => Stdlib::Httpsurl,
-        ensure => Enum[present, latest]
+        source   => Enum[git],
+        url      => Stdlib::Httpsurl,
+        ensure   => Enum[present, latest],
+        revision => Optional[String],
+        depth    => Optional[Integer]
     }]
   ]             $custom_plugins = {},
 ) {
@@ -52,7 +54,8 @@ define ohmyzsh::plugins(
       ensure   => $plugin[ensure],
       provider => $plugin[source],
       source   => $plugin[url],
-      revision => 'master',
+      depth    => $plugin[depth],
+      revision => $plugin[revision],
       require  => ::Ohmyzsh::Install[$name],
     }
   }


### PR DESCRIPTION
This allow a non standard branch to be used and do a shallow clone (depth=1)

Note: If no revision is defined, the default HEAD of the main branch has [documented here](https://github.com/puppetlabs/puppetlabs-vcsrepo#clonepull-a-repository), this is why I changed the line `revision => 'master'` to an optional parameter.
