### PR TITLE
fix disable_auto_update

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -105,6 +105,7 @@ define ohmyzsh::install (
     path  => "${home}/.zshrc",
     line  => "DISABLE_AUTO_UPDATE=\"${disable_auto_update}\"",
     match => '.*DISABLE_AUTO_UPDATE.*',
+    after => '^plugins=',
   }
 
   # Fix permissions on '~/.oh-my-zsh/cache/completions'


### PR DESCRIPTION
DISABLE_AUTO_UPDATE needs to go before the sourcing of the oh-my-zsh script to work - by default it gets appended to the end of .zshrc and has no effect so user still gets prompted for update

Note file_line can't MOVE a line once its present so this will have no effect on existing installs - to resolve, users will need to manually remove DISABLE_AUTO_UPDATE line that gets appended to end of file, then the next puppet run will put it back in the correct location.

there is probably a better more complex way of doing this by using class parameters and updating the actual template erb based on that parameter but this provided least change towards a fix