### PR TITLE
Add the package dependency for unmanaged users

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -141,6 +141,8 @@ define ohmyzsh::install (
       User <| title == $name |> {
         shell => lookup('ohmyzsh::zsh_shell_path')
       }
+
+      Package['zsh'] -> User <| title == $name |>
     }
   }
 


### PR DESCRIPTION
If the user is already defined, add the requirement of the ZSH package before changing the shell of the user.

Without this, the catalog may fail if the shell is set before the package is installed on the machine.